### PR TITLE
Added MathJax

### DIFF
--- a/app/views/layouts/_stylesheets.html.erb
+++ b/app/views/layouts/_stylesheets.html.erb
@@ -5,3 +5,14 @@
 <%= stylesheet_link_tag 'blueprint/print',  media: 'print' %>
 <!--[if lt IE 8]><%= stylesheet_link_tag 'blueprint/ie' %><![endif]-->
 <%= stylesheet_link_tag    "application", media: "all" %>
+<!-- MathJax -->
+<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>                
+<script type="text/x-mathjax-config">
+MathJax.Hub.Config({"HTML-CSS": { preferredFont: "TeX", availableFonts: ["STIX","TeX"],
+        linebreaks: { automatic:true }, EqnChunk: (MathJax.Hub.Browser.isMobile ? 10 : 50) },
+    tex2jax: { inlineMath: [ ["$", "$"], ["\\\\(","\\\\)"] ],
+        displayMath: [ ["$$","$$"], ["\\[", "\\]"] ], processEscapes: true, ignoreClass: "tex2jax_ignore|dno" },
+    TeX: {  noUndefined: { attributes: { mathcolor: "red",
+        mathbackground: "#FFEEEE", mathsize: "90%" } }, Macros: { href: "{}" } }, messageStyle: "none"
+});
+</script>


### PR DESCRIPTION
Hi Bill,

  So I thought I'd add in the JavaScript necessary to load up MathJax so that the abstracts that contain TeX-formatted math will be displayed appropriately. Should also work for comments that wish to contain maths.

  Note: I've not tested this, because I don't know much about running ruby-on-rails, but I think the place I added it is the correct spot (or at least a spot that will result it being in the header of the document), so it should work.

  Let me know if there is a better place to put it (or if you don't want this on scirate for some reason).
## 

Noon
