### PR TITLE
Removed comment about quant-ph, link to draftable redevelopment

### DIFF
--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -10,16 +10,12 @@
   To Scite papers or add comments, please create a user account from the sign-in page.
 </p>
 <p>
-  This implementation of Scirate should be considered a beta:
-  currently only <a href="http://arxiv.org/archive/quant-ph">quant-ph</a> is supported,
-  but other categories will be added in the future.
-</p>
-<p>
   Scirate is the idea of <a href="http://dabacon.org/">Dave Bacon</a>,
   but the <a href="http://scirate.com/">original implementation </a> has been down
   for some time.
   This implementation of Scirate is due to <a href="http://intractable.ca/bill">Bill Rosgen</a>.
-  To contribute, please consider visiting
+  To contribute to this version of Scirate, please consider visiting
   <a href="http://github.com/rosgen/scirate3">github.com/rosgen/scirate3</a>
-  to view the source or to help with the implementation.
+  to view the source or to help with the implementation, but note that an active redevelopment 
+  is underway at <a href="http://github.com/draftable/scirate3">github.com/draftable/scirate3</a>.
 </p>


### PR DESCRIPTION
Hi Bill,

  I know you're not developing Scirate anymore, but here is a very trivial pull request to remove a comment on the About page, if you wish to merge it. I'm removing it because I don't believe it is true, and more than one person has mentioned it to me as a reason to _not_ use Scirate.

  I also added a link to the new development of Scirate.

-- edit: (I'm only making this request because I'm assuming that the new Scirate is still a few months away.)
## 

Noon
